### PR TITLE
Fix dir_prefix not reading from storage config

### DIFF
--- a/docs/epycloud.md
+++ b/docs/epycloud.md
@@ -326,8 +326,8 @@ resources:
 - The `docker.image_tag` and `github.modeling_suite_ref` are set to `dev` by the dev environment
 - This means: `epycloud --env dev build cloud` will build the dev branch into a Docker image tagged as `dev`
 - Similarly: `epycloud --env dev run workflow --exp-id test` will use dev environment settings
-- The flu profile adds `github.forecast_repo` and `pipeline.dir_prefix` specific to flu forecasting
-- Values not specified in higher layers (like `pipeline.max_parallelism`) are inherited from base
+- The flu profile adds `github.forecast_repo` and `storage.dir_prefix` specific to flu forecasting
+- Values not specified in higher layers (like `google_cloud.batch.max_parallelism`) are inherited from base
 - Deep merge preserves unspecified nested values
 
 ### Example Configuration Files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "epycloud"
-version = "0.5.4"
+version = "0.5.5"
 description = "CLI for epymodelingsuite cloud pipeline management"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/epycloud/commands/download/handlers.py
+++ b/src/epycloud/commands/download/handlers.py
@@ -71,8 +71,8 @@ def handle(ctx: dict[str, Any]) -> int:
 
     # Resolve bucket and dir_prefix (CLI overrides take precedence)
     bucket_name = args.bucket or gcloud_config["bucket_name"]
-    pipeline_config = config.get("pipeline", {})
-    dir_prefix = args.dir_prefix or pipeline_config.get("dir_prefix", "pipeline/flu/")
+    storage_config = config.get("storage", {})
+    dir_prefix = args.dir_prefix or storage_config.get("dir_prefix", "pipeline/flu/")
 
     # Ensure dir_prefix ends with /
     if not dir_prefix.endswith("/"):

--- a/src/epycloud/commands/experiment/handlers.py
+++ b/src/epycloud/commands/experiment/handlers.py
@@ -79,8 +79,8 @@ def handle_list(ctx: dict[str, Any]) -> int:
         return 2
 
     bucket_name = args.bucket or gcloud_config["bucket_name"]
-    pipeline_config = config.get("pipeline", {})
-    dir_prefix = args.dir_prefix or pipeline_config.get("dir_prefix", "pipeline/flu/")
+    storage_config = config.get("storage", {})
+    dir_prefix = args.dir_prefix or storage_config.get("dir_prefix", "pipeline/flu/")
 
     if not dir_prefix.endswith("/"):
         dir_prefix += "/"

--- a/src/epycloud/commands/run/cloud/job.py
+++ b/src/epycloud/commands/run/cloud/job.py
@@ -90,6 +90,8 @@ def run_job_cloud(
     bucket_name = google_cloud.get("bucket_name")
     storage = config.get("storage", {})
     dir_prefix = storage.get("dir_prefix", "pipeline/flu/")
+    if dir_prefix and not dir_prefix.endswith("/"):
+        dir_prefix += "/"
     batch_config = get_batch_config(config)
     github = get_github_config(config)
     github_forecast_repo = github["forecast_repo"]

--- a/src/epycloud/commands/run/cloud/job.py
+++ b/src/epycloud/commands/run/cloud/job.py
@@ -88,8 +88,8 @@ def run_job_cloud(
     project_id = google_cloud.get("project_id")
     region = google_cloud.get("region", "us-central1")
     bucket_name = google_cloud.get("bucket_name")
-    pipeline = config.get("pipeline", {})
-    dir_prefix = pipeline.get("dir_prefix", "pipeline/flu/")
+    storage = config.get("storage", {})
+    dir_prefix = storage.get("dir_prefix", "pipeline/flu/")
     batch_config = get_batch_config(config)
     github = get_github_config(config)
     github_forecast_repo = github["forecast_repo"]

--- a/src/epycloud/commands/run/cloud/workflow.py
+++ b/src/epycloud/commands/run/cloud/workflow.py
@@ -93,8 +93,8 @@ def run_workflow_cloud(
     project_id = google_cloud.get("project_id")
     region = google_cloud.get("region", "us-central1")
     bucket_name = google_cloud.get("bucket_name")
-    pipeline = config.get("pipeline", {})
-    dir_prefix = pipeline.get("dir_prefix", "pipeline/flu/")
+    storage = config.get("storage", {})
+    dir_prefix = storage.get("dir_prefix", "pipeline/flu/")
     github = get_github_config(config)
     github_forecast_repo = github["forecast_repo"]
     github_forecast_repo_ref = github["forecast_repo_ref"]
@@ -105,7 +105,7 @@ def run_workflow_cloud(
         github_forecast_repo_ref = forecast_repo_ref_override
 
     if not max_parallelism:
-        max_parallelism = pipeline.get("max_parallelism", 100)
+        max_parallelism = batch_config.get("max_parallelism", 100)
 
     if not task_count_per_node:
         task_count_per_node = batch_config.get("task_count_per_node", 1)

--- a/src/epycloud/commands/run/cloud/workflow.py
+++ b/src/epycloud/commands/run/cloud/workflow.py
@@ -95,6 +95,8 @@ def run_workflow_cloud(
     bucket_name = google_cloud.get("bucket_name")
     storage = config.get("storage", {})
     dir_prefix = storage.get("dir_prefix", "pipeline/flu/")
+    if dir_prefix and not dir_prefix.endswith("/"):
+        dir_prefix += "/"
     github = get_github_config(config)
     github_forecast_repo = github["forecast_repo"]
     github_forecast_repo_ref = github["forecast_repo_ref"]

--- a/src/epycloud/commands/run/local/job.py
+++ b/src/epycloud/commands/run/local/job.py
@@ -69,8 +69,8 @@ def run_job_local(
     image_tag = docker.get("image_tag") or "local"
     if image_tag == "latest":
         image_tag = "local"
-    pipeline = config.get("pipeline", {})
-    dir_prefix = pipeline.get("dir_prefix", "pipeline/flu/")
+    storage = config.get("storage", {})
+    dir_prefix = storage.get("dir_prefix", "pipeline/flu/")
 
     # Auto-generate run_id for stage A if not provided
     if stage == "A" and not run_id:

--- a/src/epycloud/commands/run/local/job.py
+++ b/src/epycloud/commands/run/local/job.py
@@ -71,6 +71,8 @@ def run_job_local(
         image_tag = "local"
     storage = config.get("storage", {})
     dir_prefix = storage.get("dir_prefix", "pipeline/flu/")
+    if dir_prefix and not dir_prefix.endswith("/"):
+        dir_prefix += "/"
 
     # Auto-generate run_id for stage A if not provided
     if stage == "A" and not run_id:

--- a/src/epycloud/commands/run/local/workflow.py
+++ b/src/epycloud/commands/run/local/workflow.py
@@ -58,6 +58,8 @@ def run_workflow_local(
     image_tag = docker["image_tag"]
     storage = config.get("storage", {})
     dir_prefix = storage.get("dir_prefix", "pipeline/flu/")
+    if dir_prefix and not dir_prefix.endswith("/"):
+        dir_prefix += "/"
 
     # Generate run ID if not provided
     if not run_id:

--- a/src/epycloud/commands/run/local/workflow.py
+++ b/src/epycloud/commands/run/local/workflow.py
@@ -56,8 +56,8 @@ def run_workflow_local(
     docker = get_docker_config(config)
     image_name = docker["image_name"]
     image_tag = docker["image_tag"]
-    pipeline = config.get("pipeline", {})
-    dir_prefix = pipeline.get("dir_prefix", "pipeline/flu/")
+    storage = config.get("storage", {})
+    dir_prefix = storage.get("dir_prefix", "pipeline/flu/")
 
     # Generate run ID if not provided
     if not run_id:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,9 +117,8 @@ def mock_config():
             "modeling_suite_repo": "test-org/modeling-suite",
             "modeling_suite_ref": "main",
         },
-        "pipeline": {
+        "storage": {
             "dir_prefix": "pipeline/test/",
-            "max_parallelism": 100,
         },
         "resources": {
             "stage_a": {

--- a/uv.lock
+++ b/uv.lock
@@ -480,7 +480,7 @@ wheels = [
 
 [[package]]
 name = "epycloud"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "cairosvg" },


### PR DESCRIPTION
## Overview

`dir_prefix` was always falling back to hardcoded `"pipeline/flu/"` because the code read from `config["pipeline"]` instead of `config["storage"]` where it's actually defined. This meant env/profile overrides were silently ignored.

## Changes

- Read `dir_prefix` from `config["storage"]` instead of `config["pipeline"]` in all 6 command files
- Read `max_parallelism` from `batch_config` instead of the nonexistent `pipeline` section
- Normalize trailing slash on `dir_prefix` in run commands (download/experiment handlers already did this)
- Fix stale `pipeline.dir_prefix` reference in docs
- Update test fixture to use `storage` key
- Bump to v0.5.5