### PR TITLE
v0.6.0: Add download files flag 

### DIFF
--- a/docs/epycloud/download.md
+++ b/docs/epycloud/download.md
@@ -20,9 +20,25 @@ Downloads specific output files (plots, CSVs) from experiment runs in GCS. Autom
 | `-o, --output-dir DIR` | Optional | Output directory | `./downloads` |
 | `--name-format {long,short}` | Optional | Filename format | `long` |
 | `--nest-runs` | Flag | Add `{run_id}/` subdirectory under each experiment | Disabled |
+| `--files PATTERN` | Optional | Comma-separated filenames/globs to download, replacing the defaults | Default file set |
 | `--bucket BUCKET` | Optional | GCS bucket name | From config |
 | `--dir-prefix PREFIX` | Optional | GCS directory prefix | From config |
 | `-y, --yes` | Flag | Skip confirmation prompt | Disabled |
+
+### Selecting Files
+
+By default, each matched run's `outputs/` directory is searched for a fixed set of plots:
+
+- `posterior_grid.pdf`
+- `quantiles_grid_sidebyside.pdf`
+- `categorical_rate_trends.pdf` (only for experiments whose name starts with `hosp_`)
+
+Use `--files` to download a different set. It accepts comma-separated [fnmatch](https://docs.python.org/3/library/fnmatch.html) glob patterns and **replaces** the defaults entirely (the `hosp_` rule no longer applies). Patterns match against the file basename, e.g.:
+
+- `--files quantiles_grid_sidebyside.pdf` — a single named file
+- `--files "*.pdf"` — every PDF in `outputs/`
+- `--files "*.pdf,*.csv.gz"` — all PDFs and compressed CSVs
+- `--files "posterior_*"` — files with a given prefix
 
 ### Name Formats
 
@@ -43,6 +59,12 @@ epycloud download -e "202607/" -o ./results
 
 # Short filenames with run subdirectories
 epycloud download -e "202607/" --name-format short --nest-runs
+
+# Download only one specific plot
+epycloud download -e "202607/" --files quantiles_grid_sidebyside.pdf
+
+# Download all PDFs and compressed CSVs (glob patterns)
+epycloud download -e "202607/hosp_*" --files "*.pdf,*.csv.gz"
 
 # Skip confirmation
 epycloud download -e "202607/" -y

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "epycloud"
-version = "0.5.6"
+version = "0.6.0"
 description = "CLI for epymodelingsuite cloud pipeline management"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/epycloud/commands/download/handlers.py
+++ b/src/epycloud/commands/download/handlers.py
@@ -87,6 +87,10 @@ def handle(ctx: dict[str, Any]) -> int:
     nest_runs = args.nest_runs
     auto_confirm = args.yes
 
+    files_override = None
+    if getattr(args, "files", None):
+        files_override = [f.strip() for f in args.files.split(",") if f.strip()]
+
     if verbose:
         status(f"Bucket: {bucket_name}")
         status(f"Prefix: {dir_prefix}")
@@ -138,7 +142,7 @@ def handle(ctx: dict[str, Any]) -> int:
     for exp_path_rel in matched:
         exp_gcs_path = f"{dir_prefix}{exp_path_rel}"
         exp_name = exp_path_rel.rsplit("/", 1)[-1]
-        target_files = get_target_files(exp_path_rel)
+        target_files = files_override or get_target_files(exp_path_rel)
 
         # List run IDs
         try:

--- a/src/epycloud/commands/download/operations.py
+++ b/src/epycloud/commands/download/operations.py
@@ -1,5 +1,6 @@
 """GCS listing and downloading operations for download command."""
 
+import fnmatch
 from pathlib import Path
 
 from google.cloud import storage
@@ -85,7 +86,7 @@ def find_matching_blobs(
     matching = []
     for blob in blobs:
         blob_filename = blob.name.rsplit("/", 1)[-1]
-        if blob_filename in target_files:
+        if any(fnmatch.fnmatch(blob_filename, pat) for pat in target_files):
             matching.append(blob)
 
     return matching

--- a/src/epycloud/commands/download/parser.py
+++ b/src/epycloud/commands/download/parser.py
@@ -59,6 +59,15 @@ def register_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
     parser.add_argument(
+        "--files",
+        metavar="PATTERN",
+        help=(
+            "Comma-separated filenames/globs to download, replacing the defaults. "
+            'Examples: "quantiles_grid_sidebyside.pdf" or "*.pdf,*.csv.gz"'
+        ),
+    )
+
+    parser.add_argument(
         "-y",
         "--yes",
         action="store_true",

--- a/tests/integration/test_download_command.py
+++ b/tests/integration/test_download_command.py
@@ -22,6 +22,7 @@ def _make_ctx(mock_config, tmp_path, **overrides):
         "nest_runs": False,
         "bucket": None,
         "dir_prefix": None,
+        "files": None,
         "yes": True,
     }
     args_defaults.update(overrides)
@@ -330,6 +331,30 @@ class TestDownloadCommand:
         assert blob1.download_to_filename.called
         assert blob2.download_to_filename.called
         assert blob3.download_to_filename.called
+
+    @patch("epycloud.commands.download.handlers.storage.Client")
+    def test_files_override(self, mock_storage_client, mock_config, tmp_path):
+        """--files replaces defaults and matches by glob."""
+        run_id = "20250101-120000-abc12345"
+        pdf = Mock()
+        pdf.name = f"pipeline/test/202605/exp1/{run_id}/outputs/ts/posterior_grid.pdf"
+        csv = Mock()
+        csv.name = f"pipeline/test/202605/exp1/{run_id}/outputs/ts/extra_metrics.csv.gz"
+
+        prefix_map, run_map = _standard_prefix_map()
+        _setup_gcs_mock(
+            mock_storage_client,
+            prefix_map=prefix_map,
+            run_map=run_map,
+            blob_map={
+                f"pipeline/test/202605/exp1/{run_id}/outputs/": [pdf, csv]
+            },
+        )
+
+        ctx = _make_ctx(mock_config, tmp_path, files="*.csv.gz")
+        assert download.handle(ctx) == 0
+        assert csv.download_to_filename.called
+        assert not pdf.download_to_filename.called
 
     @patch("epycloud.commands.download.handlers.storage.Client")
     def test_exact_pattern_matches_sub_experiments(

--- a/tests/unit/test_download_operations.py
+++ b/tests/unit/test_download_operations.py
@@ -318,6 +318,66 @@ class TestFindMatchingBlobs:
         )
         assert len(result) == 2
 
+    def test_glob_pattern_matches_extension(self):
+        mock_client = Mock()
+        mock_bucket = Mock()
+        mock_client.bucket.return_value = mock_bucket
+
+        pdf = Mock()
+        pdf.name = "path/outputs/ts/a.pdf"
+        csv = Mock()
+        csv.name = "path/outputs/ts/b.csv"
+        mock_bucket.list_blobs.return_value = [pdf, csv]
+
+        result = find_matching_blobs(mock_client, "bucket", "path", ["*.pdf"])
+        assert result == [pdf]
+
+    def test_glob_prefix_pattern(self):
+        mock_client = Mock()
+        mock_bucket = Mock()
+        mock_client.bucket.return_value = mock_bucket
+
+        match = Mock()
+        match.name = "path/outputs/ts/posterior_grid.pdf"
+        other = Mock()
+        other.name = "path/outputs/ts/quantiles_grid.pdf"
+        mock_bucket.list_blobs.return_value = [match, other]
+
+        result = find_matching_blobs(mock_client, "bucket", "path", ["posterior_*"])
+        assert result == [match]
+
+    def test_exact_name_still_matches(self):
+        mock_client = Mock()
+        mock_bucket = Mock()
+        mock_client.bucket.return_value = mock_bucket
+
+        blob = Mock()
+        blob.name = "path/outputs/ts/posterior_grid.pdf"
+        mock_bucket.list_blobs.return_value = [blob]
+
+        result = find_matching_blobs(
+            mock_client, "bucket", "path", ["posterior_grid.pdf"]
+        )
+        assert result == [blob]
+
+    def test_multiple_patterns(self):
+        mock_client = Mock()
+        mock_bucket = Mock()
+        mock_client.bucket.return_value = mock_bucket
+
+        pdf = Mock()
+        pdf.name = "path/outputs/ts/x.pdf"
+        gz = Mock()
+        gz.name = "path/outputs/ts/y.csv.gz"
+        other = Mock()
+        other.name = "path/outputs/ts/z.txt"
+        mock_bucket.list_blobs.return_value = [pdf, gz, other]
+
+        result = find_matching_blobs(
+            mock_client, "bucket", "path", ["*.pdf", "*.csv.gz"]
+        )
+        assert result == [pdf, gz]
+
 
 class TestExtractScanPrefix:
     """Test extract_scan_prefix function."""

--- a/uv.lock
+++ b/uv.lock
@@ -480,7 +480,7 @@ wheels = [
 
 [[package]]
 name = "epycloud"
-version = "0.5.6"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "cairosvg" },


### PR DESCRIPTION
Adds a `--files` flag to `epycloud download` so users can choose which output files to pull, instead of the hardcoded plot set. Release as v0.6.0.

## Changes
- `--files PATTERN`: comma-separated [fnmatch](https://docs.python.org/3/library/fnmatch.html) globs that **replace** the default file list when provided.
- `find_matching_blobs` now matches by glob instead of exact name (backward-compatible. literal names still match).
- Defaults unchanged when `--files` is omitted (`posterior_grid.pdf`, `quantiles_grid_sidebyside.pdf`, + `categorical_rate_trends.pdf` for `hosp_*`).
- Docs updated (`docs/epycloud/download.md`).

## Examples
```bash
epycloud download -e "202607/" --files quantiles_grid_sidebyside.pdf
epycloud download -e "202607/hosp_*" --files "*.pdf,*.csv.gz"
```

## Tests
Passing